### PR TITLE
This will fix the dublicate video urls

### DIFF
--- a/imdb.php
+++ b/imdb.php
@@ -161,7 +161,7 @@ class Imdb
 	public function getVideos($titleId){
 		$html = $this->geturl("http://www.imdb.com/title/${titleId}/videogallery");
 		$videos = array();
-		foreach ($this->match_all('/<a.*?href="\/videoplayer\/(vi\d+).*?".*?>.*?<\/a>/ms', $html, 1) as $v) {
+		foreach ($this->match_all('/<a.*?href="\/videoplayer\/(vi\d+)\?ref_.*?".*?>.*?<\/a>/ms', $html, 1) as $v) {
 			$videos[] = "http://www.imdb.com/video/imdb/${v}";
 		}
 		return array_filter($videos);


### PR DESCRIPTION
We add "\?ref_" in the mach_all statement so it can scrape one link for each video.

Regards